### PR TITLE
Matchers addition to describe AggregateRoot behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,29 @@
-Copyright (c) 2018 Gildas Quéméner <gildas.quemener@gmail.com>
+New BSD License
+===============
 
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation
-files (the "Software"), to deal in the Software without
-restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following
-conditions:
+Copyright (c) 2018, prooph software GmbH and Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+All rights reserved.
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the names of the copyright holders nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2018 Gildas Quéméner <gildas.quemener@gmail.com>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,9 @@
+default:
+    suites:
+        default:
+            contexts:
+                - ApplicationContext
+                - FilesystemContext
+
+    autoload:
+        "": "%paths.base%/vendor/phpspec/phpspec/features/bootstrap"

--- a/bin/behat
+++ b/bin/behat
@@ -1,0 +1,1 @@
+../vendor/behat/behat/bin/behat

--- a/bin/phpspec
+++ b/bin/phpspec
@@ -1,0 +1,1 @@
+../vendor/phpspec/phpspec/bin/phpspec

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "behat/behat": "^3.4",
         "prooph/event-sourcing": "^5.3"
     },
-    "license": "MIT",
+    "license": "BSD",
     "authors": [
         {
             "name": "Gildas Quéméner",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "prooph/phpspec-extension",
-    "description": "",
+    "description": "Ease aggregate root description using PhpSpec by providing matchers",
     "type": "phpspec-extension",
     "require": {
         "php": "^7.0,<7.3",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "gquemener/prooph-phpspec-extension",
+    "name": "prooph/phpspec-extension",
     "description": "",
     "type": "phpspec-extension",
     "require": {
@@ -19,7 +19,7 @@
     ],
     "autoload": {
         "psr-4": {
-            "GQuemener\\PhpSpec\\": "src"
+            "Prooph\\PhpSpec\\": "src"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "gquemener/prooph-phpspec-extension",
+    "description": "",
+    "type": "phpspec-extension",
+    "require": {
+        "php": "^7.0,<7.3",
+        "phpspec/phpspec": "^4.0"
+    },
+    "require-dev": {
+        "behat/behat": "^3.4",
+        "prooph/event-sourcing": "^5.3"
+    },
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Gildas Quéméner",
+            "email": "gildas.quemener@gmail.com"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "GQuemener\\PhpSpec\\": "src"
+        }
+    },
+    "config": {
+        "bin-dir": "bin"
+    }
+}

--- a/features/aggregate_root_has_recorded_at_least_a_specific_event.feature
+++ b/features/aggregate_root_has_recorded_at_least_a_specific_event.feature
@@ -1,0 +1,66 @@
+Feature:
+  In order to ensure a specific event has been recorded during AggregateRoot lifecycle
+  As a developer
+  I need to be able to check recorded events collection contains a given FQCN
+
+  Background:
+    Given the config file contains:
+    """
+    extensions:
+        Prooph\PhpSpec\Extension: ~
+    """
+
+  Scenario: Successfully match expected recorded events
+    Given the spec file "spec/RecordedEvent2/HaveRecordedEventSpec.php" contains:
+    """
+    <?php
+
+    namespace spec\RecordedEvent2;
+
+    class HaveRecordedEventSpec extends \PhpSpec\ObjectBehavior
+    {
+        function it_has_recorded_an_event()
+        {
+            $this->beConstructedThrough('create', ['abc123', 'foo']);
+            $this->shouldHaveRecorded(\RecordedEvent2\Created::class);
+        }
+    }
+    """
+    And the class file "src/RecordedEvent2/HaveRecordedEvent.php" contains:
+    """
+    <?php
+
+    namespace RecordedEvent2;
+
+    class HaveRecordedEvent extends \Prooph\EventSourcing\AggregateRoot
+    {
+        public static function create(string $id)
+        {
+            $self = new self();
+            $self->recordThat(\RecordedEvent2\Created::occur('abc123'));
+
+            return $self;
+        }
+
+        protected function aggregateId(): string
+        {
+            return $this->id;
+        }
+
+        protected function apply(\Prooph\EventSourcing\AggregateChanged $event): void
+        {
+        }
+    }
+    """
+    And the class file "src/RecordedEvent2/Created.php" contains:
+    """
+    <?php
+
+    namespace RecordedEvent2;
+
+    class Created extends \Prooph\EventSourcing\AggregateChanged
+    {
+    }
+    """
+    When I run phpspec
+    Then the suite should pass

--- a/features/aggregate_root_has_recorded_events.feature
+++ b/features/aggregate_root_has_recorded_events.feature
@@ -1,0 +1,76 @@
+Feature:
+  In order to ensure specific events have been recorded during AggregateRoot lifecycle
+  As a developer
+  I need to be able to provide a callback describing what and when events must have been recorded
+
+  Background:
+    Given the config file contains:
+    """
+    extensions:
+        GQuemener\PhpSpec\Extension: ~
+    """
+
+  Scenario: Successfully match expected recorded events
+    Given the spec file "spec/HaveRecordedEventsSpec.php" contains:
+    """
+    <?php
+
+    namespace spec;
+
+    class HaveRecordedEventsSpec extends \PhpSpec\ObjectBehavior
+    {
+        function it_records_events()
+        {
+            $this->beConstructedThrough('create', ['abc123', 'foo']);
+            $this->shouldHaveRecordedEventsThat(function(array $events) {
+                foreach ($events as $event) {
+                    if ($event instanceof \Created) {
+                        return 'abc123' === $event->aggregateId() && 'foo' === $event->bar();
+                    }
+                }
+
+                return false;
+            });
+        }
+    }
+    """
+    And the class file "src/HaveRecordedEvents.php" contains:
+    """
+    <?php
+
+    class HaveRecordedEvents extends \Prooph\EventSourcing\AggregateRoot
+    {
+        public static function create(string $id, string $bar)
+        {
+            $self = new self();
+            $self->recordThat(\Created::occur('abc123', [
+              'bar' => $bar
+            ]));
+
+            return $self;
+        }
+
+        protected function aggregateId(): string
+        {
+            return $this->id;
+        }
+
+        protected function apply(\Prooph\EventSourcing\AggregateChanged $event): void
+        {
+        }
+    }
+    """
+    And the class file "src/Created.php" contains:
+    """
+    <?php
+
+    class Created extends \Prooph\EventSourcing\AggregateChanged
+    {
+        public function bar(): string
+        {
+            return $this->payload['bar'];
+        }
+    }
+    """
+    When I run phpspec
+    Then the suite should pass

--- a/features/aggregate_root_has_recorded_events.feature
+++ b/features/aggregate_root_has_recorded_events.feature
@@ -7,7 +7,7 @@ Feature:
     Given the config file contains:
     """
     extensions:
-        GQuemener\PhpSpec\Extension: ~
+        Prooph\PhpSpec\Extension: ~
     """
 
   Scenario: Successfully match expected recorded events

--- a/src/EventSourcing/AggregateExtractor.php
+++ b/src/EventSourcing/AggregateExtractor.php
@@ -1,0 +1,19 @@
+<?php
+
+declare (strict_types = 1);
+
+namespace Prooph\PhpSpec\EventSourcing;
+
+use Prooph\EventSourcing\AggregateRoot;
+
+final class AggregateExtractor
+{
+    public function extractRecordedEvents(AggregateRoot $aggregateRoot): array
+    {
+        $refl = new \ReflectionObject($aggregateRoot);
+        $prop = $refl->getProperty('recordedEvents');
+        $prop->setAccessible(true);
+
+        return $prop->getValue($aggregateRoot);
+    }
+}

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -2,11 +2,11 @@
 
 declare (strict_types = 1);
 
-namespace GQuemener\PhpSpec;
+namespace Prooph\PhpSpec;
 
 use PhpSpec\Extension as PhpSpecExtension;
 use PhpSpec\ServiceContainer;
-use GQuemener\PhpSpec\Matcher\RecordedEventsThatMatcher;
+use Prooph\PhpSpec\Matcher\RecordedEventsThatMatcher;
 
 final class Extension implements PhpSpecExtension
 {

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -7,18 +7,29 @@ namespace Prooph\PhpSpec;
 use PhpSpec\Extension as PhpSpecExtension;
 use PhpSpec\ServiceContainer;
 use Prooph\PhpSpec\Matcher;
+use Prooph\PhpSpec\EventSourcing\AggregateExtractor;
 use PhpSpec\ServiceContainer\IndexedServiceContainer;
 
 final class Extension implements PhpSpecExtension
 {
     public function load(ServiceContainer $container, array $params)
     {
+        $container->define('prooph.event_sourcing.aggregate_extractor', function (IndexedServiceContainer $c) {
+            return new AggregateExtractor();
+        });
+
         $container->define('prooph.matchers.recorded_events_that', function (IndexedServiceContainer $c) {
-            return new Matcher\RecordedEventsThatMatcher($c->get('formatter.presenter'));
+            return new Matcher\RecordedEventsThatMatcher(
+                $c->get('formatter.presenter'),
+                $c->get('prooph.event_sourcing.aggregate_extractor')
+            );
         }, ['matchers']);
 
         $container->define('prooph.matchers.recorded_event', function (IndexedServiceContainer $c) {
-            return new Matcher\RecordedEventMatcher($c->get('formatter.presenter'));
+            return new Matcher\RecordedEventMatcher(
+                $c->get('formatter.presenter'),
+                $c->get('prooph.event_sourcing.aggregate_extractor')
+);
         }, ['matchers']);
     }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -6,14 +6,19 @@ namespace Prooph\PhpSpec;
 
 use PhpSpec\Extension as PhpSpecExtension;
 use PhpSpec\ServiceContainer;
-use Prooph\PhpSpec\Matcher\RecordedEventsThatMatcher;
+use Prooph\PhpSpec\Matcher;
+use PhpSpec\ServiceContainer\IndexedServiceContainer;
 
 final class Extension implements PhpSpecExtension
 {
     public function load(ServiceContainer $container, array $params)
     {
-        $container->define('gquemener.matchers.recorded_events_that', function ($c) {
-            return new RecordedEventsThatMatcher($c->get('formatter.presenter'));
+        $container->define('prooph.matchers.recorded_events_that', function (IndexedServiceContainer $c) {
+            return new Matcher\RecordedEventsThatMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+
+        $container->define('prooph.matchers.recorded_event', function (IndexedServiceContainer $c) {
+            return new Matcher\RecordedEventMatcher($c->get('formatter.presenter'));
         }, ['matchers']);
     }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -1,0 +1,19 @@
+<?php
+
+declare (strict_types = 1);
+
+namespace GQuemener\PhpSpec;
+
+use PhpSpec\Extension as PhpSpecExtension;
+use PhpSpec\ServiceContainer;
+use GQuemener\PhpSpec\Matcher\RecordedEventsThatMatcher;
+
+final class Extension implements PhpSpecExtension
+{
+    public function load(ServiceContainer $container, array $params)
+    {
+        $container->define('gquemener.matchers.recorded_events_that', function ($c) {
+            return new RecordedEventsThatMatcher($c->get('formatter.presenter'));
+        }, ['matchers']);
+    }
+}

--- a/src/Matcher/RecordedEventMatcher.php
+++ b/src/Matcher/RecordedEventMatcher.php
@@ -1,0 +1,89 @@
+<?php
+
+declare (strict_types = 1);
+
+namespace Prooph\PhpSpec\Matcher;
+
+use PhpSpec\Matcher\BasicMatcher;
+use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Exception\Example\FailureException;
+
+final class RecordedEventMatcher extends BasicMatcher
+{
+    /**
+     * @var Presenter
+     */
+    private $presenter;
+
+    /**
+     * @param Presenter $presenter
+     */
+    public function __construct(Presenter $presenter)
+    {
+        $this->presenter = $presenter;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return bool
+     */
+    public function supports(string $name, $subject, array $arguments): bool
+    {
+        return 'haveRecorded' === $name
+            && 1 === \count($arguments)
+        ;
+    }
+
+    /**
+     * @param mixed $subject
+     * @param array $arguments
+     *
+     * @return bool
+     */
+    protected function matches($subject, array $arguments): bool
+    {
+        $refl = new \ReflectionObject($subject);
+        $prop = $refl->getProperty('recordedEvents');
+        $prop->setAccessible(true);
+        $events = $prop->getValue($subject);
+
+        return count(array_filter($events, function($event) use ($arguments) {
+            return $arguments[0] === get_class($event);
+        })) > 0;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
+     */
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    {
+        return new FailureException(sprintf(
+            'Expected %s to have recorded at least one %s event, but it has not.',
+            $this->presenter->presentValue($subject),
+            $this->presenter->presentValue($arguments[0])
+        ));
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
+     */
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    {
+        return new FailureException(sprintf(
+            'Expected %s not to have recorded a %s event, but it has.',
+            $this->presenter->presentValue($subject),
+            $this->presenter->presentValue($arguments[0])
+        ));
+    }
+}

--- a/src/Matcher/RecordedEventMatcher.php
+++ b/src/Matcher/RecordedEventMatcher.php
@@ -7,6 +7,7 @@ namespace Prooph\PhpSpec\Matcher;
 use PhpSpec\Matcher\BasicMatcher;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
+use Prooph\EventSourcing\AggregateRoot;
 use Prooph\PhpSpec\EventSourcing\AggregateExtractor;
 
 final class RecordedEventMatcher extends BasicMatcher
@@ -28,6 +29,7 @@ final class RecordedEventMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveRecorded' === $name
+            && $subject instanceof AggregateRoot
             && 1 === \count($arguments)
         ;
     }

--- a/src/Matcher/RecordedEventsThatMatcher.php
+++ b/src/Matcher/RecordedEventsThatMatcher.php
@@ -2,7 +2,7 @@
 
 declare (strict_types = 1);
 
-namespace GQuemener\PhpSpec\Matcher;
+namespace Prooph\PhpSpec\Matcher;
 
 use PhpSpec\Matcher\BasicMatcher;
 use PhpSpec\Formatter\Presenter\Presenter;

--- a/src/Matcher/RecordedEventsThatMatcher.php
+++ b/src/Matcher/RecordedEventsThatMatcher.php
@@ -7,6 +7,7 @@ namespace Prooph\PhpSpec\Matcher;
 use PhpSpec\Matcher\BasicMatcher;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
+use Prooph\EventSourcing\AggregateRoot;
 use Prooph\PhpSpec\EventSourcing\AggregateExtractor;
 
 final class RecordedEventsThatMatcher extends BasicMatcher
@@ -31,6 +32,7 @@ final class RecordedEventsThatMatcher extends BasicMatcher
     public function supports(string $name, $subject, array $arguments): bool
     {
         return 'haveRecordedEventsThat' === $name
+            && $subject instanceof AggregateRoot
             && 1 === \count($arguments)
             && \is_callable($arguments[0])
         ;

--- a/src/Matcher/RecordedEventsThatMatcher.php
+++ b/src/Matcher/RecordedEventsThatMatcher.php
@@ -1,0 +1,88 @@
+<?php
+
+declare (strict_types = 1);
+
+namespace GQuemener\PhpSpec\Matcher;
+
+use PhpSpec\Matcher\BasicMatcher;
+use PhpSpec\Formatter\Presenter\Presenter;
+use PhpSpec\Exception\Example\FailureException;
+
+final class RecordedEventsThatMatcher extends BasicMatcher
+{
+    /**
+     * @var Presenter
+     */
+    private $presenter;
+
+    /**
+     * @param Presenter $presenter
+     */
+    public function __construct(Presenter $presenter)
+    {
+        $this->presenter = $presenter;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return bool
+     */
+    public function supports(string $name, $subject, array $arguments): bool
+    {
+        return 'haveRecordedEventsThat' === $name
+            && 1 === \count($arguments)
+            && \is_callable($arguments[0])
+        ;
+    }
+
+    /**
+     * @param mixed $subject
+     * @param array $arguments
+     *
+     * @return bool
+     */
+    protected function matches($subject, array $arguments): bool
+    {
+        $refl = new \ReflectionObject($subject);
+        $prop = $refl->getProperty('recordedEvents');
+        $prop->setAccessible(true);
+        $events = $prop->getValue($subject);
+
+        return $arguments[0]($events);
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
+     */
+    protected function getFailureException(string $name, $subject, array $arguments): FailureException
+    {
+        return new FailureException(sprintf(
+            'Expected %s to have recorded events that %s, but it has not.',
+            $this->presenter->presentValue($subject),
+            $this->presenter->presentValue($arguments[0])
+        ));
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $subject
+     * @param array  $arguments
+     *
+     * @return FailureException
+     */
+    protected function getNegativeFailureException(string $name, $subject, array $arguments): FailureException
+    {
+        return new FailureException(sprintf(
+            'Expected %s not to have recorded events that %s, but it has.',
+            $this->presenter->presentValue($subject),
+            $this->presenter->presentValue($arguments[0])
+        ));
+    }
+}

--- a/src/Matcher/RecordedEventsThatMatcher.php
+++ b/src/Matcher/RecordedEventsThatMatcher.php
@@ -7,20 +7,18 @@ namespace Prooph\PhpSpec\Matcher;
 use PhpSpec\Matcher\BasicMatcher;
 use PhpSpec\Formatter\Presenter\Presenter;
 use PhpSpec\Exception\Example\FailureException;
+use Prooph\PhpSpec\EventSourcing\AggregateExtractor;
 
 final class RecordedEventsThatMatcher extends BasicMatcher
 {
-    /**
-     * @var Presenter
-     */
     private $presenter;
 
-    /**
-     * @param Presenter $presenter
-     */
-    public function __construct(Presenter $presenter)
-    {
+    public function __construct(
+        Presenter $presenter,
+        AggregateExtractor $extractor
+    ) {
         $this->presenter = $presenter;
+        $this->extractor = $extractor;
     }
 
     /**
@@ -46,10 +44,7 @@ final class RecordedEventsThatMatcher extends BasicMatcher
      */
     protected function matches($subject, array $arguments): bool
     {
-        $refl = new \ReflectionObject($subject);
-        $prop = $refl->getProperty('recordedEvents');
-        $prop->setAccessible(true);
-        $events = $prop->getValue($subject);
+        $events = $this->extractor->extractRecordedEvents($subject);
 
         return $arguments[0]($events);
     }


### PR DESCRIPTION
Here's a list of the added matchers:
- `haveRecordedEvent`: check that at least one event matching the provided FQCN has been recorded.
- `haveRecordedEventsThat`: check that aggregate root has recorded events that validates conditions provided through a callback.